### PR TITLE
when generating the namespace hash add a random string suffix to the user provided name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,8 @@ runs:
         set -u
 
         if [ '${{ inputs.sanitize-name == 'true' }}' = true ]; then
-          HASH="$(printf %s "$NAME" | sha256sum)"
+          rand_str=$(tr -dc a-z0-9 < /dev/urandom | head -c 8)
+          HASH="$(printf %s "$NAME-$rand_str" | sha256sum)"
           NAME="$(printf %s "$NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/')"
           NAME="$(printf b%.8s-%.7s "$NAME" "$HASH" | sed -E 's/[^a-z0-9]+/-/')"
         fi


### PR DESCRIPTION
This PR aims to solve the problem where re-running a workflow results in the generation of the same namespace when the [name input](https://github.com/cloudbees-io/create-k8s-namespace/blob/562986e3a0619ecdbe068575f96773f6d9776d6f/action.yml#L7-L11) to the action remains unchanged on a re-run and the action is invoked with the [sanitize-name input](https://github.com/cloudbees-io/create-k8s-namespace/blob/562986e3a0619ecdbe068575f96773f6d9776d6f/action.yml#L12-L14) set to true.