### PR TITLE
Revert "when generating the namespace hash add a random string suffix  to the user provided name"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,8 +37,7 @@ runs:
         set -u
 
         if [ '${{ inputs.sanitize-name == 'true' }}' = true ]; then
-          rand_str=$(tr -dc a-z0-9 < /dev/urandom | head -c 8)
-          HASH="$(printf %s "$NAME-$rand_str" | sha256sum)"
+          HASH="$(printf %s "$NAME" | sha256sum)"
           NAME="$(printf %s "$NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/')"
           NAME="$(printf b%.8s-%.7s "$NAME" "$HASH" | sed -E 's/[^a-z0-9]+/-/')"
         fi


### PR DESCRIPTION


This reverts commit dcb63c0f3353fb6e1e0506d527d1403f8761b123.

Reverting this change because current workflows in Production invoke the namespace creation action multiple times and end up getting a new namespace for each invocation due to this change which breaks the pipeline.